### PR TITLE
Fix file handling in helper and base processor

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -13,7 +13,10 @@ import pygtrie
 
 
 def get_num(dataset_path, dataset, mode='entity'):  # mode: {entity, relation}
-    return int(open(os.path.join(dataset_path, dataset, mode + '2id.txt')).readline().strip())
+    file_path = os.path.join(dataset_path, dataset, mode + '2id.txt')
+    with open(file_path, "r", encoding="utf-8") as file:
+        first_line = file.readline().strip()
+    return int(first_line)
 
 
 def read(configs, dataset_path, dataset, filename):

--- a/script/base.py
+++ b/script/base.py
@@ -30,7 +30,9 @@ class Processor:
     def read_json_file(self, filename, in_folder=None, dataset=None):
         in_folder = self.in_folder if in_folder is None else in_folder
         dataset = self.dataset if dataset is None else dataset
-        return json.load(open(os.path.join(in_folder, dataset, filename)))
+        file_path = os.path.join(in_folder, dataset, filename)
+        with open(file_path, encoding="utf-8") as file:
+            return json.load(file)
 
     def write_file(self, filename, out_folder=None, dataset=None, sort_key=None, func=lambda x: x):
         out_folder = self.out_folder if out_folder is None else out_folder


### PR DESCRIPTION
## Summary
- use context managers when reading count files
- ensure JSON file handles are closed properly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
